### PR TITLE
make it so top level configuration resources inherit their name from …

### DIFF
--- a/conf/autoscaling/groups/example-scale-group.json
+++ b/conf/autoscaling/groups/example-scale-group.json
@@ -9,7 +9,6 @@
   "load-balancers": [
 
   ],
-  "name": "example-scale-group",
   "policies": {
     "static": [
       "example-static"

--- a/conf/iam/groups/example-group.json
+++ b/conf/iam/groups/example-group.json
@@ -1,5 +1,4 @@
 {
-  "name": "example-group",
   "policies": {
     "attached": [],
     "static": [

--- a/conf/iam/roles/example-role.json
+++ b/conf/iam/roles/example-role.json
@@ -1,5 +1,4 @@
 {
-  "name": "example-role",
   "policy-document": "default",
   "policies": {
     "attached": [],

--- a/conf/iam/users/example-user.json
+++ b/conf/iam/users/example-user.json
@@ -1,5 +1,4 @@
 {
-  "name": "example-user",
   "policies": {
     "attached": [],
     "static": [

--- a/lib/autoscaling/loader/Loader.rb
+++ b/lib/autoscaling/loader/Loader.rb
@@ -8,10 +8,10 @@ module Loader
   include BaseLoader
 
   @@groups_dir = Configuration.instance.autoscaling.groups_directory
-  @@group_loader = Proc.new { |json| GroupConfig.new(json) }
+  @@group_loader = Proc.new { |name, json| GroupConfig.new(name, json) }
   @@static_dir = Configuration.instance.autoscaling.static_policy_directory
   @@template_dir = Configuration.instance.autoscaling.template_policy_directory
-  @@policy_loader = Proc.new { |json| PolicyConfig.new(json) }
+  @@policy_loader = Proc.new { |name, json| PolicyConfig.new(json) }
 
   # Public: Load all autoscaling group configurations as GroupConfig objects
   #

--- a/lib/autoscaling/models/GroupConfig.rb
+++ b/lib/autoscaling/models/GroupConfig.rb
@@ -26,9 +26,10 @@ class GroupConfig
 
   # Public: Constructor
   #
+  # name - the name of the group
   # json - a hash containing the json configuration for the AutoScaling group
-  def initialize(json)
-    @name = json["name"]
+  def initialize(name, json)
+    @name = name
     @cooldown = json["cooldown-seconds"]
     @min = json["size"]["min"]
     @max = json["size"]["max"]

--- a/lib/common/BaseLoader.rb
+++ b/lib/common/BaseLoader.rb
@@ -23,7 +23,8 @@ module BaseLoader
   # dir     - the directory the file is located in
   # loader  - the function that will handle the read json
   def self.resource(file, dir, &loader)
-    loader.call(JSON.parse(load_file(file, dir)))
+    name = file.end_with?(".json") ? file[0...-5] : file
+    loader.call(name, JSON.parse(load_file(file, dir)))
   end
 
   # Internal: Load the template, apply variables, and pass the parsed JSON to
@@ -40,7 +41,7 @@ module BaseLoader
     end
     json = JSON.parse(template)
 
-    loader.call(json)
+    loader.call(nil, json)
   end
 
   # Internal: Load a file. Will check if a file exists by the name passed in, or

--- a/lib/iam/loader/Loader.rb
+++ b/lib/iam/loader/Loader.rb
@@ -12,15 +12,15 @@ require "json"
 module Loader
   include BaseLoader
 
-  @@group_loader = Proc.new { |json| GroupConfig.new(json) }
+  @@group_loader = Proc.new { |name, json| GroupConfig.new(name, json) }
   @@groups_dir = Configuration.instance.iam.groups_directory
-  @@role_loader = Proc.new { |json| RoleConfig.new(json) }
+  @@role_loader = Proc.new { |name, json| RoleConfig.new(name, json) }
   @@roles_dir = Configuration.instance.iam.roles_directory
-  @@user_loader = Proc.new { |json| UserConfig.new(json) }
+  @@user_loader = Proc.new { |name, json| UserConfig.new(name, json) }
   @@users_dir = Configuration.instance.iam.users_directory
   @@static_policy_dir = Configuration.instance.iam.static_policy_directory
   @@template_dir = Configuration.instance.iam.template_policy_directory
-  @@policy_loader = Proc.new do |json|
+  @@policy_loader = Proc.new do |name, json|
     if json.is_a?(Array)
       json.map do |s|
         StatementConfig.new(s)

--- a/lib/iam/models/GroupConfig.rb
+++ b/lib/iam/models/GroupConfig.rb
@@ -9,10 +9,11 @@ class GroupConfig < ResourceWithPolicy
 
   # Public: Constructor
   #
+  # name - the name of the group
   # json - the Hash containing the JSON configuration for this GroupConfig, if
   #        nil, this will be an "empty GroupConfig"
-  def initialize(json = nil)
-    super(json)
+  def initialize(name = nil, json = nil)
+    super(name, json)
     @type = "group"
     @users = json["users"] unless json.nil?
   end

--- a/lib/iam/models/ResourceWithPolicy.rb
+++ b/lib/iam/models/ResourceWithPolicy.rb
@@ -24,11 +24,12 @@ class ResourceWithPolicy
 
   # Public: Constructor.
   #
+  # name - the name of the resource
   # json - a hash containing JSON configuration for this resource, if nil, this
   #        resource will be an "empty resource"
-  def initialize(json = nil)
+  def initialize(name = nil, json = nil)
     if !json.nil?
-      @name = json["name"]
+      @name = name
       @json = json
       @attached_policies = json["policies"]["attached"]
       @statics = json["policies"]["static"]

--- a/lib/iam/models/RoleConfig.rb
+++ b/lib/iam/models/RoleConfig.rb
@@ -1,5 +1,5 @@
-require "iam/models/ResourceWithPolicy"
 
+require "iam/models/ResourceWithPolicy"
 # Public: Represents a config file for a role. Will lazily load its static and
 # template policies as needed.
 class RoleConfig < ResourceWithPolicy
@@ -8,10 +8,11 @@ class RoleConfig < ResourceWithPolicy
 
   # Public: Constructor.
   #
+  # name - the name of the role
   # json - the Hash containing the JSON configuration for this RoleConfig, if
   #        nil, this will be an "empty RoleConfig"
-  def initialize(json = nil)
-    super(json)
+  def initialize(name = nil, json = nil)
+    super(name, json)
     @policy_document = Loader.policy_document(json["policy-document"]) unless json.nil?
     @type = "role"
   end

--- a/lib/iam/models/UserConfig.rb
+++ b/lib/iam/models/UserConfig.rb
@@ -6,10 +6,11 @@ class UserConfig < ResourceWithPolicy
 
   # Public: Constructor
   #
+  # name - the name of the user
   # json - the Hash containing the JSON configuration for this UserConfig, if
   #        nil, this will be an "empty UserConfig"
-  def initialize(json = nil)
-    super(json)
+  def initialize(name = nil, json = nil)
+    super(name, json)
     @type = "user"
   end
 


### PR DESCRIPTION
…the file name, and not from a property in the json file. Fixes #4 
