### PR TITLE
security-groups: fix bug where having multiple security groups in a r…

### DIFF
--- a/lib/security/models/RuleConfig.rb
+++ b/lib/security/models/RuleConfig.rb
@@ -104,13 +104,27 @@ class RuleConfig
   #
   # Returns the hash
   def hash
-    {
-      "security-groups" => @security_groups,
-      "protocol" => protocol,
-      "from-port" => @from,
-      "to-port" => @to,
-      "subnets" => @subnets,
-    }.reject { |k, v| v.nil? }
+    security_hashes = @security_groups.map do |security_group|
+      {
+        "security-groups" => [security_group],
+        "protocol" => protocol,
+        "from-port" => @from,
+        "to-port" => @to,
+        "subnets" => [],
+      }.reject { |k, v| v.nil? }
+    end
+    subnet_hashes = if !@subnets.empty?
+      [{
+        "security-groups" => [],
+        "protocol" => protocol,
+        "from-port" => @from,
+        "to-port" => @to,
+        "subnets" => @subnets
+      }.reject { |k, v| v.nil? }]
+    else
+      []
+    end
+    security_hashes + subnet_hashes
   end
 
 end

--- a/lib/security/models/SecurityGroupConfig.rb
+++ b/lib/security/models/SecurityGroupConfig.rb
@@ -115,11 +115,11 @@ class SecurityGroupConfig
     aws = aws_rules.map do |rule|
       RuleConfig.from_aws(rule, sg_ids_to_names)
     end
-    aws_hashes = aws.map(&:hash)
-    local_hashes = local_rules.map(&:hash)
+    aws_hashes = aws.flat_map(&:hash)
+    local_hashes = local_rules.flat_map(&:hash)
 
-    diffs << local_rules.reject { |i| aws_hashes.include?(i.hash) }.map { |l| RuleDiff.added(l) }
-    diffs << aws.reject { |a| local_hashes.include?(a.hash) }.map { |a| RuleDiff.removed(a) }
+    diffs << local_hashes.reject { |i| aws_hashes.include?(i) }.map { |l| RuleDiff.added(RuleConfig.new(l)) }
+    diffs << aws_hashes.reject { |a| local_hashes.include?(a) }.map { |a| RuleDiff.removed(RuleConfig.new(a)) }
 
     diffs.flatten
   end


### PR DESCRIPTION
…ule made the diff always fail

This fix makes it so when hashes are generated for diffing, all security groups are split into separate RuleConfig objects so they can still be diffed with AWS.
