### PR TITLE
security-groups: fix bug where because subnets were unordered, differ…

### DIFF
--- a/lib/security/models/RuleConfig.rb
+++ b/lib/security/models/RuleConfig.rb
@@ -86,7 +86,7 @@ class RuleConfig
         else
           subnet
         end
-      end
+      end.sort
     else
       []
     end


### PR DESCRIPTION
…ent orderings were causing subnet lists to look different
