### PR TITLE
s3: make the feedback from diffing configurable

### DIFF
--- a/conf/configuration.json
+++ b/conf/configuration.json
@@ -55,7 +55,8 @@
 			"policies": {
 				"directory": "conf/s3/policies"
 			}
-		}
+		},
+		"print-progress": true
 	},
 	"security": {
 		"groups": {

--- a/lib/conf/Configuration.rb
+++ b/lib/conf/Configuration.rb
@@ -202,6 +202,7 @@ module Cumulus
       attr_reader :buckets_directory
       attr_reader :cors_directory
       attr_reader :policies_directory
+      attr_reader :print_progress
 
       # Public: Constructor
       def initialize
@@ -209,6 +210,7 @@ module Cumulus
         @buckets_directory = conf_abs_path "s3.buckets.directory"
         @cors_directory = conf_abs_path "s3.buckets.cors.directory"
         @policies_directory = conf_abs_path "s3.buckets.policies.directory"
+        @print_progress = conf "s3.print-progress"
       end
     end
 

--- a/lib/s3/manager/Manager.rb
+++ b/lib/s3/manager/Manager.rb
@@ -63,7 +63,9 @@ module Cumulus
       end
 
       def diff_resource(local, aws)
-        puts "diffing #{local.name}"
+        if Configuration.instance.s3.print_progress
+          puts "checking for differences in #{local.name}"
+        end
         full_aws = S3.full_bucket(aws.name)
         local.diff(full_aws)
       end


### PR DESCRIPTION
It used to print out all the time...
