### PR TITLE
Exit with different status codes when there are diffs when diffing/syncing

### DIFF
--- a/lib/common/manager/Manager.rb
+++ b/lib/common/manager/Manager.rb
@@ -1,5 +1,6 @@
 require "common/models/Diff"
 require "util/Colors"
+require "util/StatusCodes"
 
 module Cumulus
   module Common
@@ -87,6 +88,9 @@ module Cumulus
       # diffs - the differences between local configuration and AWS
       def print_difference(key, diffs)
         if diffs.size > 0
+
+          StatusCodes::set_status(StatusCodes::DIFFS)
+
           if diffs.size == 1 and (diffs[0].type == DiffChange::ADD or
             diffs[0].type == DiffChange::UNMANAGED)
             puts diffs[0]
@@ -106,6 +110,9 @@ module Cumulus
       # diffs - the differences between local configuration and AWS
       def sync_difference(key, diffs)
         if diffs.size > 0
+
+          StatusCodes::set_status(StatusCodes::SYNC_DIFFS)
+
           if diffs[0].type == DiffChange::UNMANAGED
             puts diffs[0]
           elsif diffs[0].type == DiffChange::ADD

--- a/lib/util/StatusCodes.rb
+++ b/lib/util/StatusCodes.rb
@@ -1,0 +1,51 @@
+module Cumulus
+
+  # Public: Provide methods for setting the status code that
+  #         Cumulus should exit with
+  module StatusCodes
+
+    # Indicates that we are exiting normally
+    OK = 0
+
+    # Indicates there was an exception during execution
+    EXCEPTION = 1
+
+    # Indicates that there were diffs
+    DIFFS = 2
+
+    # Indicates that there were diffs and they were synced
+    SYNC_DIFFS = 3
+
+    # Static attributes and methods for keeping track of status codes
+    class << self
+      # Holds the value for the current status
+      @@CURRENT_STATUS = OK
+
+      # Public: Sets the status code if it is more severe than the current status code
+      def set_status(status)
+
+        # Only set the status if we are not already in exception state
+        if @@CURRENT_STATUS != EXCEPTION
+
+          # Only set the status if it is more severe (higher) than the current status
+          if status > @@CURRENT_STATUS
+            @@CURRENT_STATUS = status
+          end
+
+        end
+      end
+
+      # On exit, if the exit was successful, exit with the
+      # status codes that describes what happened while running
+      at_exit  do
+
+        if $!.nil? || ($!.is_a?(SystemExit) && $!.success?)
+          exit @@CURRENT_STATUS
+        end
+
+      end
+
+    end
+
+  end
+end


### PR DESCRIPTION
This will be most useful when automatically running diff/sync and alerting based on whether or not there are changes
