### PR TITLE
Allow autoscaling groups to reference subnets by vpc name/id and subn…

### DIFF
--- a/lib/autoscaling/models/AutoScalingDiff.rb
+++ b/lib/autoscaling/models/AutoScalingDiff.rb
@@ -100,9 +100,8 @@ module Cumulus
           lines.flatten.join("\n")
         when SUBNETS
           lines = ["Subnets:"]
-          aws_subnets = @aws.vpc_zone_identifier.split(",")
-          lines << (aws_subnets - @local.subnets).map { |s| "\t#{Colors.removed(s)}" }
-          lines << (@local.subnets - aws_subnets).map { |s| "\t#{Colors.added(s)}" }
+          lines << (@aws - @local).map { |s| s.vpc_subnet_name || s.subnet_id }.map { |s| "\t#{Colors.removed(s)}" }
+          lines << (@local - @aws).map { |s| s.vpc_subnet_name || s.subnet_id }.map { |s| "\t#{Colors.added(s)}" }
           lines.flatten.join("\n")
         when TAGS
           tags_diff_string

--- a/lib/aws_extensions/ec2/Subnet.rb
+++ b/lib/aws_extensions/ec2/Subnet.rb
@@ -1,3 +1,5 @@
+require "ec2/EC2"
+
 module AwsExtensions
   module EC2
     module Subnet
@@ -7,6 +9,13 @@ module AwsExtensions
         self.tags.select { |tag| tag.key == "Name" }.first.value
       rescue
         nil
+      end
+
+      # Public: Returns the name of the security group prefixed by the vpc name or id
+      def vpc_subnet_name
+        vpc = Cumulus::EC2::id_vpcs[self.vpc_id]
+        vpc_name = vpc.name || vpc.vpd_id
+        "#{vpc_name}/#{self.name}"
       end
 
       # Implement comparison by using subnet id


### PR DESCRIPTION
…et name instead of subnet id only
