### PR TITLE
iam error fixes, fixes #125

### DIFF
--- a/lib/aws_extensions/iam/Policy.rb
+++ b/lib/aws_extensions/iam/Policy.rb
@@ -1,0 +1,22 @@
+require "json"
+require "deepsort"
+
+module AwsExtensions
+  module IAM
+    module Policy
+      def as_hash
+        # Sort the statments to prevent false conflicts while diffing
+        sorted_policy = JSON.parse(URI.unescape(policy_document)).deep_sort
+        sorted_policy["Statement"].each do |statement|
+          # actions sometimes contains a single string element instead of the expected array
+          statement["Action"] = [statement["Action"]] if statement["Action"].is_a? String
+          # resources sometimes contains a single string element instead of the expected array
+          statement["Resource"] = [statement["Resource"]] if statement["Resource"].is_a? String
+        end
+        # return the sorted policy hash
+        sorted_policy
+      end
+    end
+  end
+end
+

--- a/lib/iam/models/PolicyConfig.rb
+++ b/lib/iam/models/PolicyConfig.rb
@@ -1,5 +1,5 @@
 require "conf/Configuration"
-
+require "deepsort"
 require "json"
 
 module Cumulus
@@ -59,7 +59,7 @@ module Cumulus
         {
           "Version" => @version,
           "Statement" => statements
-        }
+        }.deep_sort
       end
 
     end

--- a/lib/iam/models/ResourceWithPolicy.rb
+++ b/lib/iam/models/ResourceWithPolicy.rb
@@ -170,7 +170,12 @@ module Cumulus
 
         aws_policies = Hash[aws_resource.policies.map do |policy|
           # Sort the statments before diffing to prevent false conflicts
-          [policy.name, JSON.parse(URI.unescape(policy.policy_document)).deep_sort]
+          sorted_policy = JSON.parse(URI.unescape(policy.policy_document)).deep_sort
+          action = sorted_policy["Statement"]["Action"]
+          sorted_policy["Statment"]["Action"] = [action] if action.is_a? String
+          resource = sorted_policy["Statement"]["Resource"]
+          sorted_policy["Statement"]["Resource"] = [resource] if resource.is_a? String
+          [policy.name, sorted_policy]
         end]
         p = policy
         p.name = generated_policy_name

--- a/lib/iam/models/ResourceWithPolicy.rb
+++ b/lib/iam/models/ResourceWithPolicy.rb
@@ -4,6 +4,7 @@ require "iam/models/IamDiff"
 require "iam/models/PolicyConfig"
 require "iam/models/StatementConfig"
 require "util/Colors"
+require "deepsort"
 
 require "json"
 
@@ -168,13 +169,8 @@ module Cumulus
         diffs = []
 
         aws_policies = Hash[aws_resource.policies.map do |policy|
-          sorted_policy = JSON.parse(URI.unescape(policy.policy_document))
-          sorted_policy["Statement"].each do |statement|
-            # Sort the statments before diffing to prevent false conflicts
-            statement["Action"].sort!
-            statement["Resource"].sort!
-          end
-          [policy.name, sorted_policy]
+          # Sort the statments before diffing to prevent false conflicts
+          [policy.name, JSON.parse(URI.unescape(policy.policy_document)).deep_sort]
         end]
         p = policy
         p.name = generated_policy_name

--- a/lib/iam/models/StatementConfig.rb
+++ b/lib/iam/models/StatementConfig.rb
@@ -12,8 +12,9 @@ module Cumulus
       # json - the Hash containing the JSON configuration for this StatementConfig
       def initialize(json)
         @effect = json["Effect"]
-        @action = json["Action"].sort
-        @resource = json["Resource"].sort
+        # Action and Resource elements are sometimes strings instead of arrays of strings.
+        @action = json["Action"].sort if json["Action"].respond_to? :sort
+        @resource = json["Resource"].sort if json["Resource"].respond_to? :sort
         @condition = json["Condition"]
       end
 

--- a/lib/iam/models/StatementConfig.rb
+++ b/lib/iam/models/StatementConfig.rb
@@ -13,8 +13,22 @@ module Cumulus
       def initialize(json)
         @effect = json["Effect"]
         # Action and Resource elements are sometimes strings instead of arrays of strings.
-        @action = json["Action"].sort if json["Action"].respond_to? :sort
-        @resource = json["Resource"].sort if json["Resource"].respond_to? :sort
+        @action = if json["Action"].is_a? Array
+          json["Action"].sort
+        elsif json["Action"].is_a? String
+          # convert single element strings into arrays
+          json["Action"] = [json["Action"]]
+        else
+          raise Exception.new("invalid policy statement resource")
+        end
+        @resource = if json["Resource"].is_a? Array
+          json["Resource"].sort
+        elsif json["Resource"].is_a? String
+          # convert single element strings into arrays
+          json["Resource"] = [json["Resource"]]
+        else
+          raise Exception.new("invalid policy statement resource")
+        end
         @condition = json["Condition"]
       end
 
@@ -23,12 +37,12 @@ module Cumulus
       #
       # Returns the Hash representing this StatementConfig.
       def as_hash
-        {
+        Hash[{
           "Effect" => @effect,
           "Action" => @action,
           "Resource" => @resource,
           "Condition" => @condition
-        }.reject { |k, v| v.nil? }
+        }.sort].reject { |k, v| v.nil? }
       end
 
     end


### PR DESCRIPTION
this mainly fixes the errors when the aws sdk returns a string for a single element "Action" or "Resource" in a policy statement. In addition, it also fixes the related error caused when these policies try to sort the "Action" or "Resource" arrays.
Users can now use strings instead of arrays in locally defined configs if there is only one element.
